### PR TITLE
fix: resolve routing, caching, and capability transaction bugs

### DIFF
--- a/common/src/main/java/jagm/classicpipes/blockentity/DiamondFluidPipeEntity.java
+++ b/common/src/main/java/jagm/classicpipes/blockentity/DiamondFluidPipeEntity.java
@@ -41,7 +41,7 @@ public class DiamondFluidPipeEntity extends FluidPipeEntity implements MenuProvi
             }
             direction = MiscUtil.nextDirection(direction);
         }
-        if (validDirections.isEmpty() && filter.directionMatches(bucket, direction).matches) {
+        if (validDirections.isEmpty() && filter.directionMatches(bucket, fluidPacket.getFromDirection()).matches) {
             validDirections.add(fluidPacket.getFromDirection());
         }
         if (validDirections.isEmpty()) {

--- a/common/src/main/java/jagm/classicpipes/blockentity/DiamondPipeEntity.java
+++ b/common/src/main/java/jagm/classicpipes/blockentity/DiamondPipeEntity.java
@@ -55,7 +55,7 @@ public class DiamondPipeEntity extends RoundRobinPipeEntity implements MenuProvi
         } else if (!matchPriority.get(Filter.MatchingResult.MOD).isEmpty()) {
             validDirections.addAll(matchPriority.get(Filter.MatchingResult.MOD));
         }
-        if (validDirections.isEmpty() && filter.directionMatches(item.getStack(), direction).matches) {
+        if (validDirections.isEmpty() && filter.directionMatches(item.getStack(), item.getFromDirection()).matches) {
             validDirections.add(item.getFromDirection());
         }
         if (validDirections.isEmpty()) {

--- a/common/src/main/java/jagm/classicpipes/blockentity/NetworkedPipeEntity.java
+++ b/common/src/main/java/jagm/classicpipes/blockentity/NetworkedPipeEntity.java
@@ -247,6 +247,7 @@ public abstract class NetworkedPipeEntity extends RoundRobinPipeEntity {
                     current.setChanged();
                     level.sendBlockUpdated(current.getBlockPos(), current.getBlockState(), current.getBlockState(), 2);
                 }
+                return;
             }
             for (Direction side : current.networkDistances.keySet()) {
                 Tuple<BlockPos, Integer> tuple = current.networkDistances.get(side);

--- a/common/src/main/java/jagm/classicpipes/blockentity/RecipePipeEntity.java
+++ b/common/src/main/java/jagm/classicpipes/blockentity/RecipePipeEntity.java
@@ -74,13 +74,15 @@ public class RecipePipeEntity extends NetworkedPipeEntity implements MenuProvide
     public void tickServer(ServerLevel level, BlockPos pos, BlockState state) {
         super.tickServer(level, pos, state);
         BlockPos crafterPos = pos.relative(this.slotDirections[9]);
-        if (this.crafterTicked && this.hasNetwork()) {
-            for (RequestedItem requestedItem : this.getNetwork().getRequestedItems()) {
-                if (requestedItem.matches(this.getResult(), true)) {
-                    requestedItem.sendMessage(level, Component.translatable("chat." + ClassicPipes.MOD_ID + ".crafter_jammed", crafterPos.toShortString()).withStyle(ChatFormatting.RED));
+        if (this.crafterTicked) {
+            if (this.hasNetwork()) {
+                for (RequestedItem requestedItem : this.getNetwork().getRequestedItems()) {
+                    if (requestedItem.matches(this.getResult(), true)) {
+                        requestedItem.sendMessage(level, Component.translatable("chat." + ClassicPipes.MOD_ID + ".crafter_jammed", crafterPos.toShortString()).withStyle(ChatFormatting.RED));
+                    }
                 }
+                this.getNetwork().resetRequests(level);
             }
-            this.getNetwork().resetRequests(level);
             this.crafterTicked = false;
             this.waitingForCraft = 0;
             this.setChanged();
@@ -282,10 +284,7 @@ public class RecipePipeEntity extends NetworkedPipeEntity implements MenuProvide
 
     @Override
     public void setRemoved() {
-        if (this.getLevel() instanceof ServerLevel serverLevel) {
-            super.disconnect(serverLevel);
-        }
-        this.remove = true;
+        super.setRemoved();
     }
 
     @Override

--- a/common/src/main/java/jagm/classicpipes/item/TagLabelItem.java
+++ b/common/src/main/java/jagm/classicpipes/item/TagLabelItem.java
@@ -101,11 +101,7 @@ public class TagLabelItem extends LabelItem {
     public boolean itemMatches(ItemStack tagStack, ItemStack compareStack) {
         String tag = tagStack.get(ClassicPipes.LABEL_COMPONENT);
         if (tag != null) {
-            for (TagKey<Item> tagKey : compareStack.tags().toList()) {
-                if (tag.equals(tagKey.location().toString())) {
-                    return true;
-                }
-            }
+            return compareStack.tags().anyMatch(tagKey -> tag.equals(tagKey.location().toString()));
         }
         return false;
     }

--- a/common/src/main/java/jagm/classicpipes/util/PipeNetwork.java
+++ b/common/src/main/java/jagm/classicpipes/util/PipeNetwork.java
@@ -282,7 +282,7 @@ public class PipeNetwork {
                 i++;
             }
         } else if (pipeToUpdate < this.providerPipes.size() + this.matchingPipes.size()) {
-            int i = 0;
+            int i = this.providerPipes.size();
             for (MatchingPipe matchingPipe : this.matchingPipes) {
                 if (i == pipeToUpdate) {
                     matchingPipe.updateCache();
@@ -291,7 +291,7 @@ public class PipeNetwork {
                 i++;
             }
         } else if (pipeToUpdate < updatablePipesCount) {
-            int i = 0;
+            int i = this.providerPipes.size() + this.matchingPipes.size();
             for (StockingPipeEntity stockingPipe : this.stockingPipes) {
                 if (i == pipeToUpdate) {
                     stockingPipe.updateCache();

--- a/neoforge/src/main/java/jagm/classicpipes/blockentity/NeoForgeFluidPipeWrapper.java
+++ b/neoforge/src/main/java/jagm/classicpipes/blockentity/NeoForgeFluidPipeWrapper.java
@@ -80,9 +80,10 @@ public class NeoForgeFluidPipeWrapper extends SnapshotJournal<Tuple<FluidResourc
     @Override
     protected void onRootCommit(Tuple<FluidResource, FluidInPipe> originalState) {
         if (!this.fluidPacketToInsert.a().matches(FluidStack.EMPTY) && this.fluidPacketToInsert.b() != null && this.pipe.getLevel() instanceof ServerLevel serverLevel) {
-            this.pipe.setFluid(new FluidWithData(fluidPacketToInsert.a().getFluid(), fluidPacketToInsert.a().getComponentsPatch()));
-            this.pipe.insertFluidPacket(serverLevel, fluidPacketToInsert.b());
+            this.pipe.setFluid(new FluidWithData(this.fluidPacketToInsert.a().getFluid(), this.fluidPacketToInsert.a().getComponentsPatch()));
+            this.pipe.insertFluidPacket(serverLevel, this.fluidPacketToInsert.b());
             serverLevel.sendBlockUpdated(this.pipe.getBlockPos(), this.pipe.getBlockState(), this.pipe.getBlockState(), 2);
+            this.fluidPacketToInsert = new Tuple<>(FluidResource.EMPTY, null);
         }
     }
 

--- a/neoforge/src/main/java/jagm/classicpipes/blockentity/NeoForgeItemPipeWrapper.java
+++ b/neoforge/src/main/java/jagm/classicpipes/blockentity/NeoForgeItemPipeWrapper.java
@@ -75,6 +75,7 @@ public class NeoForgeItemPipeWrapper extends SnapshotJournal<ItemStack> implemen
     protected void onRootCommit(ItemStack originalState) {
         if (!this.itemToInsert.isEmpty()) {
             this.pipe.setItem(this.side, this.itemToInsert);
+            this.itemToInsert = ItemStack.EMPTY;
         }
     }
 


### PR DESCRIPTION
While reviewing the codebase, I identified a few logic errors in pipe network caching, diamond pipe bounce-back routing, A* search termination, and capability transaction cleanup in NeoForge wrappers. This PR resolves these issues and eliminates redundant collection allocations in tag matching.

### Changes Proposed:
**Fixes & Stability:**
* Fixed periodic cache update indexing in `PipeNetwork` so matching and stocking pipes are properly selected for cache refreshes during network ticks.
* Corrected the direction parameter passed to `filter.directionMatches` in `DiamondPipeEntity` and `DiamondFluidPipeEntity` when testing entry face bounce-back.
* Added an early `return` in `NetworkedPipeEntity.schedulePath` once the target is reached, preventing redundant graph exploration.
* Reset pending insertion fields in `NeoForgeItemPipeWrapper` and `NeoForgeFluidPipeWrapper` upon root commit to prevent item and fluid duplication across subsequent transactions.
* Ensured `RecipePipeEntity` resets jam state even when disconnected from a network and correctly invokes `super.setRemoved()` during block entity destruction.

**Performance & Chores:**
* Replaced `.toList()` with `Stream.anyMatch` in `TagLabelItem.itemMatches` to eliminate heap allocations during pipe tick evaluations.